### PR TITLE
Adding NetCorePublishItemsOutputGroup to support VS installer project scenarios

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -842,6 +842,26 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--
+    ============================================================
+                                        NetCorePublishItemsOutputGroup
+
+    Emit an output group containing all files that get published.  This will be consumed by VS installer projects.
+    ============================================================
+    -->
+  <PropertyGroup>
+    <NetCorePublishItemsOutputGroupDependsOn>
+      $(NetCorePublishItemsOutputGroupDependsOn);
+      ComputeFilesToPublish;
+    </NetCorePublishItemsOutputGroupDependsOn>
+  </PropertyGroup>
+
+  <Target Name="NetCorePublishItemsOutputGroup" DependsOnTargets="$(NetCorePublishItemsOutputGroupDependsOn)" Returns="@(NetCorePublishItemsOutputGroupOutputs)">
+    <ItemGroup>
+      <NetCorePublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')" TargetPath="%(ResolvedFileToPublish.RelativePath)" OutputGroup="NetCorePublishItemsOutputGroup" />
+    </ItemGroup>
+  </Target>
+
+  <!--
     This target exists for back-compat with Azure Functions SDK: https://github.com/dotnet/cli/issues/10363
     Because build copy-local now behaves the same as publish with respect to package dependency resolution,
     the Azure Functions SDK doesn't need to resolve publish assets for build.

--- a/src/Tests/Microsoft.NET.Publish.Tests/NetCorePublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/NetCorePublishItemsOutputGroupTests.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class NetCorePublishItemsOutputGroupTests : SdkTest
+    {
+        public NetCorePublishItemsOutputGroupTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private static List<string> FrameworkAssemblies = new List<string>()
+        {
+            "api-ms-win-core-console-l1-1-0.dll",
+            "System.Runtime.dll",
+            "WindowsBase.dll",
+        };
+
+        [CoreMSBuildOnlyFact]
+        public void GroupPopulatedWithRid()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86", "/t:NetCorePublishItemsOutputGroup")
+                .Should()
+                .Pass();
+
+            var testOutputDir = Path.Combine(testAsset.Path, testProject.Name, "TestOutput");
+            Log.WriteLine("Contents of NetCorePublishItemsOutputGroup dumped to '{0}'.", testOutputDir);
+
+            // Check for the existence of a few specific files that should be in the directory where the 
+            // contents of NetCorePublishItemsOutputGroup were dumped to make sure it's getting populated.
+            Assert.True(File.Exists(Path.Combine(testOutputDir, $"{testProject.Name}.exe")), $"Assembly {testProject.Name}.exe is present in the output group.");
+            foreach (var assem in FrameworkAssemblies)
+            {
+                Assert.True(File.Exists(Path.Combine(testOutputDir, assem)), $"Assembly {assem} is present in the output group.");
+            }
+        }
+
+        [CoreMSBuildOnlyFact]
+        public void GroupNotPopulatedWithoutRid()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/t:NetCorePublishItemsOutputGroup")
+                .Should()
+                .Pass();
+
+            var testOutputDir = Path.Combine(testAsset.Path, testProject.Name, "TestOutput");
+            Log.WriteLine("Contents of NetCorePublishItemsOutputGroup dumped to '{0}'.", testOutputDir);
+
+            // Since no RID was specified the output group should only contain framework dependent output
+            Assert.True(File.Exists(Path.Combine(testOutputDir, $"{testProject.Name}.exe")), $"Assembly {testProject.Name}.exe is present in the output group.");
+            foreach (var assem in FrameworkAssemblies)
+            {
+                Assert.False(File.Exists(Path.Combine(testOutputDir, assem)), $"Assembly {assem} is not present in the output group.");
+            }
+        }
+
+        private TestProject SetupProject()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TestPublishOutputGroup",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = "win-x86";
+
+            //  Use a test-specific packages folder
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+
+            // Add a target that will dump the contents of the NetCorePublishItemsOutputGroup to
+            // a test directory after building.
+            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                "CopyNetCorePublishItemsOutputGroup",
+                "NetCorePublishItemsOutputGroup",
+                "@(NetCorePublishItemsOutputGroupOutputs)",
+                "$(MSBuildProjectDirectory)\\TestOutput"));
+
+            return testProject;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/CopyFilesTarget.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/CopyFilesTarget.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.TestFramework
+{
+    /// <summary>
+    /// Represents a target that will copy some set of files to a given location after some other target completes.
+    /// Useful for verifying the contents of an output group in a test.
+    /// </summary>
+    public class CopyFilesTarget
+    {
+        public CopyFilesTarget(string targetName, string targetToRunAfter, string sourceFiles, string destination)
+        {
+            TargetName = targetName;
+            TargetToRunAfter = targetToRunAfter;
+            SourceFiles = sourceFiles;
+            Destination = destination;
+        }
+
+        public string TargetName { get; private set; }
+        public string TargetToRunAfter { get; private set; }
+        public string SourceFiles { get; private set; }
+        public string Destination { get; private set; }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -36,6 +36,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         public List<TestPackageReference> PackageReferences { get; } = new List<TestPackageReference>();
 
         public List<TestPackageReference> DotNetCliToolReferences { get; } = new List<TestPackageReference>();
+        
+        public List<CopyFilesTarget> CopyFilesTargets { get; } = new List<CopyFilesTarget>();
 
         public Dictionary<string, string> SourceFiles { get; } = new Dictionary<string, string>();
 
@@ -268,6 +270,22 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 {
                     referenceItemGroup.Add(new XElement(ns + "Reference",
                         new XAttribute("Include", reference)));
+                }
+            }
+            
+            if (this.CopyFilesTargets.Any())
+            {
+                foreach (var copyFilesTarget in CopyFilesTargets)
+                {
+                    var target = new XElement(ns + "Target",
+                        new XAttribute("Name", copyFilesTarget.TargetName),
+                        new XAttribute("AfterTargets", copyFilesTarget.TargetToRunAfter));
+
+                    target.Add(new XElement(ns + "Copy",
+                        new XAttribute("SourceFiles", copyFilesTarget.SourceFiles),
+                        new XAttribute("DestinationFolder", copyFilesTarget.Destination)));
+
+                    projectXml.Root.Add(target);
                 }
             }
 


### PR DESCRIPTION
VS installer projects need to be able to access an output group that contains publishing outputs in order to create MSIs for self contained deployment, so I'm adding NetCorePublishItemsOutputGroup to the publishing targets.